### PR TITLE
Make verify() follow the specs and actually return null on failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,8 +91,8 @@ hotp.verify = function(token, key, opt) {
 		}
 	}
 
-	// If we get to here then no codes have matched, return false
-	return false;
+	// If we get to here then no codes have matched, return null
+	return null;
 };
 
 var totp = {};


### PR DESCRIPTION
Could save a developer some time if the code actually did what the documentation said. I chose to fix the code instead of the docs because it seem to make more sense to return `null` than `false` (because the return should look like `Object`s)

The mocha tests are passing.
