### PR TITLE
Replace the equal signs in base32 string

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,8 +45,11 @@ var key = 'secret key for the user';
 // encoded will be the secret key, base32 encoded
 var encoded = base32.encode(key);
 
+// Google authenticator doesn't like equal signs
+var encodedForGoogle = encoded.toString().replace(/=/g,'');
+
 // to create a URI for a qr code (change totp to hotp is using hotp)
-var uri = 'otpauth://totp/somelabel?secret=' + encoded;
+var uri = 'otpauth://totp/somelabel?secret=' + encodedForGoogle;
 ```
 
 Note: If your label has spaces or other invalid uri characters you will need to encode it accordingly using `encodeURIComponent` More details about the uri key format can be found on the [google auth wiki](https://code.google.com/p/google-authenticator/wiki/KeyUriFormat)


### PR DESCRIPTION
I updated the documentation with an example fix for Google Authenticator. It seems to dislike equal signs, so we strip them out to obtain the new `secret`.

Also note, the `thirty-two` node module now returns buffers instead of a string, so we're forced to convert it to a string first.
