### PR TITLE
Fix bug when v is < 1000000 and substr fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,9 +43,9 @@ hotp.gen = function(key, opt) {
 		(h[offset + 2] & 0xff) << 8  |
 		(h[offset + 3] & 0xff);
 
-	v = v + '';
+	v = (v % 1000000) + '';
 
-	return v.substr(v.length - p, p);
+	return Array(7-v.length).join('0') + v;
 };
 
 /**


### PR DESCRIPTION
For v less 1m e.g. 12345 previous code would try to get substr(-1,6). This happens once in 21307 attempts.