### PR TITLE
Don't check for NODE_ENV

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,9 +123,6 @@ totp.gen = function(key, opt) {
 
 	// Time has been overwritten.
 	if(opt._t) {
-		if(process.env.NODE_ENV != 'test') {
-			throw new Error('cannot overwrite time in non-test environment!');
-		}
 		_t = opt._t;
 	}
 
@@ -174,9 +171,6 @@ totp.verify = function(token, key, opt) {
 
 	// Time has been overwritten.
 	if(opt._t) {
-		if(process.env.NODE_ENV != 'test') {
-			throw new Error('cannot overwrite time in non-test environment!');
-		}
 		_t = opt._t;
 	}
 


### PR DESCRIPTION
As discussed in https://github.com/guyht/notp/issues/29 there is no advantage to disallowing the manipulation of `opt._t` in any case where a client has arbitrary access to `opt.window`.
