### PR TITLE
added an option for determined number of characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ hotp.gen = function(key, opt) {
 	key = key || '';
 	opt = opt || {};
 	var counter = opt.counter || 0;
-	var characters = opt.characters || 4;
+	var characters = opt.characters || 6;
 	var modulo = '1';
 	
 	for(var x = characters; x--;) modulo = modulo + '0'; 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ hotp.gen = function(key, opt) {
 		(h[offset + 1] & 0xff) << 16 |
 		(h[offset + 2] & 0xff) << 8  |
 		(h[offset + 3] & 0xff);
-		console.log(v);
 	
 	v = (v % parseInt(modulo)) + '';
 	

--- a/index.js
+++ b/index.js
@@ -22,8 +22,10 @@ hotp.gen = function(key, opt) {
 	key = key || '';
 	opt = opt || {};
 	var counter = opt.counter || 0;
-
-	var p = 6;
+	var characters = opt.characters || 4;
+	var modulo = '1';
+	
+	for(var x = characters; x--;) modulo = modulo + '0'; 
 
 	// Create the byte array
 	var b = new Buffer(intToBytes(counter));
@@ -42,10 +44,11 @@ hotp.gen = function(key, opt) {
 		(h[offset + 1] & 0xff) << 16 |
 		(h[offset + 2] & 0xff) << 8  |
 		(h[offset + 3] & 0xff);
-
-	v = (v % 1000000) + '';
-
-	return Array(7-v.length).join('0') + v;
+		console.log(v);
+	
+	v = (v % parseInt(modulo)) + '';
+	
+	return Array((characters + 1)-v.length).join('0') + v;
 };
 
 /**


### PR DESCRIPTION
added additional `opt` property called `characters`. When defined, it sets the number of generated characters. Can only support up to `10`. Defining it to `0` would result in an empty output.

Currently set to `6` as default.
