### PR TITLE
allow arbitrary number of digits (not hard-coded to 6)

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,12 +68,10 @@ hotp.gen = function(key, opt) {
 
 	// Truncate
 	var offset = h[19] & 0xf;
-	var v = (
-		(h[offset] & 0xff) << 24 |
+	var v = (h[offset] & 0x7f) << 24 |
 		(h[offset + 1] & 0xff) << 16 |
 		(h[offset + 2] & 0xff) << 8  |
-		(h[offset + 3] & 0xff)
-	) >>> 0;
+		(h[offset + 3] & 0xff);
 
 	v = (v % Math.pow(10, p)) + '';
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ hotp.gen = function(key, opt) {
 	opt = opt || {};
 	var counter = opt.counter || 0;
 
-	var p = 6;
+	var p = opt.digits || 6;
 
 	// Create the byte array
 	var b = new Buffer(intToBytes(counter));
@@ -68,14 +68,16 @@ hotp.gen = function(key, opt) {
 
 	// Truncate
 	var offset = h[19] & 0xf;
-	var v = (h[offset] & 0x7f) << 24 |
+	var v = (
+		(h[offset] & 0xff) << 24 |
 		(h[offset + 1] & 0xff) << 16 |
 		(h[offset + 2] & 0xff) << 8  |
-		(h[offset + 3] & 0xff);
+		(h[offset + 3] & 0xff)
+	) >>> 0;
 
-	v = (v % 1000000) + '';
+	v = (v % Math.pow(10, p)) + '';
 
-	return Array(7-v.length).join('0') + v;
+	return new Array((p+1)-v.length).join('0') + v;
 };
 
 /**


### PR DESCRIPTION
The variable `p` is defined as 6, but cannot be adjusted by `opt.digits` (and isn't actually used).

This change is especially important for authenticators that allow 8 digits.

~~Also, this uses all 32 bits of the integer and triple shifts by 0 to force it to stay a positive integer.~~