### PR TITLE
chore: correct jsdoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ totp.gen = function(key, opt) {
  *         E.g. if W = 5, and C = 1000, this function will check the passcode
  *         against all One Time Passcodes between 995 and 1005.
  *
- *         Default - 6
+ *         Default - 50
  *
  *     time - The time step of the counter.  This must be the same for
  *         every request and is used to calculate C.


### PR DESCRIPTION
Hi,

using the module I noticed that the doc mentions a default of 6 for the window of function totp, but in the code it's set to hotp's default window which is 50. I changed this in the JSdoc.