### PR TITLE
Replace deprecated Buffer constructors with Buffer.from

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,9 +56,9 @@ hotp.gen = function(key, opt) {
 	var p = 6;
 
 	// Create the byte array
-	var b = new Buffer(intToBytes(counter));
+	var b = Buffer.from(intToBytes(counter));
 
-	var hmac = crypto.createHmac('sha1', new Buffer(key));
+	var hmac = crypto.createHmac('sha1', Buffer.from(key));
 
 	// Update the HMAC with the byte array
 	var digest = hmac.update(b).digest('hex');


### PR DESCRIPTION
new Buffer() has been deprecated for a while now while still being used in the node.js version.

I've replaced the constructor call with their new replacements which is Buffer.from() and Buffer.alloc().

Reference:
https://nodejs.org/docs/latest-v18.x/api/buffer.html